### PR TITLE
[#216] SyncCommand: Refactor toString to getAsString during Price construction

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SyncCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SyncCommand.java
@@ -127,7 +127,7 @@ public class SyncCommand extends Command {
                     .get(CURRENCY_TYPE)
                     .getAsJsonObject()
                     .get("PRICE")
-                    .toString()));
+                    .getAsString()));
 
             priceObjs.put(code, newCurrentPrice);
         }


### PR DESCRIPTION
Fixes: #216 