### PR TITLE
MainApp: Fix rulebook init

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -116,7 +116,7 @@ public class MainApp extends Application {
             if (!ruleBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with an empty rule book");
             }
-            initialRules = new RuleBook();
+            initialRules = ruleBookOptional.orElseGet(RuleBook::new);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty rule book");
             initialRules = new RuleBook();


### PR DESCRIPTION
The app would always start with an empty rulebook due to this copy-paste error.