### PR TITLE
Fix Rule Actions

### DIFF
--- a/src/main/java/seedu/address/commons/events/model/CoinChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/CoinChangedEvent.java
@@ -1,6 +1,9 @@
 //@@author ewaldhew
 package seedu.address.commons.events.model;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.BaseEvent;
 import seedu.address.model.coin.Coin;
 
@@ -11,10 +14,13 @@ public class CoinChangedEvent extends BaseEvent {
 
     private static final String FORMAT_STRING = "Coin changed [%1$s] -> [%2$s]";
 
+    public final Index index;
     public final Coin data;
 
-    public CoinChangedEvent(Coin oldCoin, Coin newCoin) {
+    public CoinChangedEvent(Index index, Coin oldCoin, Coin newCoin) {
+        requireAllNonNull(index, oldCoin, newCoin);
         assert(newCoin.getPrevState().equals(oldCoin));
+        this.index = index;
         this.data = newCoin;
     }
 

--- a/src/main/java/seedu/address/logic/RuleChecker.java
+++ b/src/main/java/seedu/address/logic/RuleChecker.java
@@ -21,7 +21,6 @@ import seedu.address.model.rule.Rule;
 public class RuleChecker {
 
     private static final Logger logger = LogsCenter.getLogger(RuleChecker.class);
-    private static final String MESSAGE_PROCESS_RULE = "Found %1$s";
 
     private final RuleBook rules;
 
@@ -39,6 +38,8 @@ public class RuleChecker {
     @Subscribe
     public void handleCoinChangedEvent(CoinChangedEvent cce) {
         for (Rule r : rules.getRuleList()) {
+            r.action.setExtraData(cce.data, cce);
+
             switch (r.type) {
             case NOTIFICATION:
                 assert(r instanceof NotificationRule);
@@ -65,7 +66,6 @@ public class RuleChecker {
         }
 
         try {
-            rule.action.setExtraData(data);
             rule.action.execute();
             logger.info(String.format(Rule.MESSAGE_FIRED, rule, data));
             return true;

--- a/src/main/java/seedu/address/logic/commands/ActionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ActionCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import seedu.address.commons.events.BaseEvent;
+
 /**
  * Represents an action with some optional context of a given type
  * with hidden internal logic and the ability to be executed,
@@ -7,5 +9,10 @@ package seedu.address.logic.commands;
  * Allows for extra context data to be set during rule testing.
  */
 public abstract class ActionCommand<T> extends Command {
-    public abstract void setExtraData(T extra);
+    /**
+     * Sets the additional data required by this action
+     * @param data The object that matched this rule
+     * @param event The event that triggered this rule check
+     */
+    public abstract void setExtraData(T data, BaseEvent event);
 }

--- a/src/main/java/seedu/address/logic/commands/NotifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NotifyCommand.java
@@ -33,12 +33,6 @@ public class NotifyCommand extends Command {
     }
 
     @Override
-    public void setData(Model model, CommandHistory history, UndoRedoStack undoRedoStack) {
-        super.setData(model, history, undoRedoStack);
-        rule.action.setData(model, history, undoRedoStack);
-    }
-
-    @Override
     public CommandResult execute() throws CommandException {
         requireNonNull(model);
         try {

--- a/src/main/java/seedu/address/logic/commands/NotifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NotifyCommand.java
@@ -3,10 +3,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.address.logic.CommandHistory;
-import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
 import seedu.address.model.rule.NotificationRule;
 import seedu.address.model.rule.exceptions.DuplicateRuleException;
 

--- a/src/main/java/seedu/address/logic/commands/SpawnNotificationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SpawnNotificationCommand.java
@@ -4,6 +4,8 @@ package seedu.address.logic.commands;
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.commons.events.model.CoinChangedEvent;
 import seedu.address.commons.events.ui.ShowNotificationRequestEvent;
 import seedu.address.model.coin.Coin;
 
@@ -14,20 +16,23 @@ public class SpawnNotificationCommand extends ActionCommand<Coin> {
 
     private final String message;
     private Coin jumpTo;
+    private Index index;
 
     public SpawnNotificationCommand(String message) {
         this.message = message;
     }
 
     @Override
-    public void setExtraData(Coin targetCoin) {
-        jumpTo = targetCoin;
+    public void setExtraData(Coin data, BaseEvent event) {
+        assert(event instanceof CoinChangedEvent);
+
+        jumpTo = data;
+        index = ((CoinChangedEvent) event).index;
     }
 
     @Override
     public CommandResult execute() {
         try {
-            Index index = new CommandTarget(jumpTo.getCode()).toIndex(model.getFilteredCoinList());
             EventsCenter.getInstance()
                     .post(new ShowNotificationRequestEvent(message, index, jumpTo.getCode().toString()));
         } catch (IndexOutOfBoundsException e) {

--- a/src/main/java/seedu/address/model/CoinBook.java
+++ b/src/main/java/seedu/address/model/CoinBook.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.model.CoinChangedEvent;
 import seedu.address.model.coin.Coin;
 import seedu.address.model.coin.Price;
@@ -115,8 +116,8 @@ public class CoinBook implements ReadOnlyCoinBook {
         // TODO: the tags master list will be updated even though the below line fails.
         // This can cause the tags master list to have additional tags that are not tagged to any coin
         // in the coin list.
-        EventsCenter.getInstance().post(new CoinChangedEvent(target, editedCoin));
-        coins.setCoin(target, syncedEditedCoin);
+        Index replacedIndex = coins.setCoin(target, syncedEditedCoin);
+        EventsCenter.getInstance().post(new CoinChangedEvent(replacedIndex, target, editedCoin));
     }
     //@@author neilish3re
 

--- a/src/main/java/seedu/address/model/coin/UniqueCoinList.java
+++ b/src/main/java/seedu/address/model/coin/UniqueCoinList.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.coin.exceptions.CoinNotFoundException;
 import seedu.address.model.coin.exceptions.DuplicateCoinException;
@@ -52,7 +53,7 @@ public class UniqueCoinList implements Iterable<Coin> {
      * @throws DuplicateCoinException if the replacement is equivalent to another existing coin in the list.
      * @throws CoinNotFoundException if {@code target} could not be found in the list.
      */
-    public void setCoin(Coin target, Coin editedCoin)
+    public Index setCoin(Coin target, Coin editedCoin)
             throws DuplicateCoinException, CoinNotFoundException {
         requireNonNull(editedCoin);
 
@@ -66,6 +67,8 @@ public class UniqueCoinList implements Iterable<Coin> {
         }
 
         internalList.set(index, editedCoin);
+
+        return Index.fromZeroBased(index);
     }
 
 


### PR DESCRIPTION
This fixes the jump to coin after restarting, since rule-actions do not have their `model` field set by `LogicManager` after a restart. This removes dependency with `Model` and all necessary information for execution must be encapsulated in the event that starts the rule check.